### PR TITLE
Use row subtitles to display the hashes

### DIFF
--- a/src/hashbrown.cr
+++ b/src/hashbrown.cr
@@ -50,6 +50,7 @@ module Hashbrown
 
   ACTION_ROWS = gen_hash(false)
 
+  CSS = Gtk::CssProvider.new
 
   APP = Adw::Application.new("dev.geopjr.Hashbrown", Gio::ApplicationFlags::None)
 end

--- a/src/hashbrown.cr
+++ b/src/hashbrown.cr
@@ -9,7 +9,7 @@ require "./modules/views/tools/*"
 macro gen_hash(buttons)
   {
   {% for hash, index in Hashbrown::HASH_FUNCTIONS %}
-    {{hash.upcase}} => {% if buttons %} Gtk::Button.cast(B_HS["copyBtn{{index + 1}}"]) {% else %} Gtk::Entry.cast(B_HS["textField{{index + 1}}"]) {% end %},
+    {{hash.upcase}} => {% if buttons %} Gtk::Button.cast(B_HS["copyBtn{{index + 1}}"]) {% else %} Adw::ActionRow.cast(B_HS["hashRow{{index + 1}}"]) {% end %},
   {% end %}
   }
 end
@@ -48,7 +48,8 @@ module Hashbrown
 
   CLIPBOARD_HASH = Hash(String, String).new
 
-  TEXT_FIELDS = gen_hash(false)
+  ACTION_ROWS = gen_hash(false)
+
 
   APP = Adw::Application.new("dev.geopjr.Hashbrown", Gio::ApplicationFlags::None)
 end

--- a/src/modules/functions/generate_hash.cr
+++ b/src/modules/functions/generate_hash.cr
@@ -32,16 +32,15 @@ module Hashbrown
     tempBtns = Hash(Gtk::Button, String).new
     channel = Channel(Hash(String, String)).new
 
-    TEXT_FIELDS.keys.each do |k|
+    ACTION_ROWS.keys.each do |k|
       spawn(calculate_hash("#{k}", filename, channel))
     end
 
-    (0..TEXT_FIELDS.size - 1).each do |x|
+    ACTION_ROWS.keys.each do |_|
       output = channel.receive
       hash_type = output.keys.first
       hash_value = output[hash_type]
-
-      TEXT_FIELDS[hash_type].buffer.set_text(hash_value, hash_value.size)
+      ACTION_ROWS[hash_type].subtitle = hash_value.gsub(/.{1,4}/) { |x| x + " " }[0..-2]
       CLIPBOARD_HASH[hash_type] = hash_value
     end
   end

--- a/src/modules/ui/hash_list.ui
+++ b/src/modules/ui/hash_list.ui
@@ -8,22 +8,10 @@
         <property name="halign">center</property>
         <property name="valign">center</property>
         <child>
-          <object class="AdwActionRow">
+          <object class="AdwActionRow" id="hashRow1">
             <property name="title">MD5</property>
             <property name="selectable">0</property>
             <property name="focusable">0</property>
-            <child>
-              <object class="AdwClamp">
-                <property name="tightening-threshold">500</property>
-                <child>
-                  <object class="GtkEntry" id="textField1">
-                    <property name="valign">center</property>
-                    <property name="editable">0</property>
-                    <property name="max-width-chars">30</property>
-                  </object>
-                </child>
-              </object>
-            </child>
             <child>
               <object class="GtkButton" id="copyBtn1">
                 <property name="tooltip-text" translatable="yes">HASHBROWN_(Copy)</property>
@@ -34,20 +22,16 @@
                 </style>
               </object>
             </child>
+            <style>
+              <class name="hash-row"/>
+            </style>
           </object>
         </child>
         <child>
-          <object class="AdwActionRow">
+          <object class="AdwActionRow" id="hashRow2">
             <property name="title">SHA-1</property>
             <property name="selectable">0</property>
             <property name="focusable">0</property>
-            <child>
-              <object class="GtkEntry" id="textField2">
-                <property name="valign">center</property>
-                <property name="editable">0</property>
-                <property name="max-width-chars">30</property>
-              </object>
-            </child>
             <child>
               <object class="GtkButton" id="copyBtn2">
                 <property name="tooltip-text" translatable="yes">HASHBROWN_(Copy)</property>
@@ -58,20 +42,16 @@
                 </style>
               </object>
             </child>
+            <style>
+              <class name="hash-row"/>
+            </style>
           </object>
         </child>
         <child>
-          <object class="AdwActionRow">
+          <object class="AdwActionRow" id="hashRow3">
             <property name="title">SHA-256</property>
             <property name="selectable">0</property>
             <property name="focusable">0</property>
-            <child>
-              <object class="GtkEntry" id="textField3">
-                <property name="valign">center</property>
-                <property name="editable">0</property>
-                <property name="max-width-chars">30</property>
-              </object>
-            </child>
             <child>
               <object class="GtkButton" id="copyBtn3">
                 <property name="tooltip-text" translatable="yes">HASHBROWN_(Copy)</property>
@@ -82,20 +62,16 @@
                 </style>
               </object>
             </child>
+            <style>
+              <class name="hash-row"/>
+            </style>
           </object>
         </child>
         <child>
-          <object class="AdwActionRow">
+          <object class="AdwActionRow" id="hashRow4">
             <property name="title">SHA-512</property>
             <property name="selectable">0</property>
             <property name="focusable">0</property>
-            <child>
-              <object class="GtkEntry" id="textField4">
-                <property name="valign">center</property>
-                <property name="editable">0</property>
-                <property name="max-width-chars">30</property>
-              </object>
-            </child>
             <child>
               <object class="GtkButton" id="copyBtn4">
                 <property name="tooltip-text" translatable="yes">HASHBROWN_(Copy)</property>
@@ -106,6 +82,9 @@
                 </style>
               </object>
             </child>
+            <style>
+              <class name="hash-row"/>
+            </style>
           </object>
         </child>
         <style>

--- a/src/modules/ui/style.css
+++ b/src/modules/ui/style.css
@@ -1,0 +1,3 @@
+.hash-row .subtitle {
+  font-family: monospace;
+}

--- a/src/modules/views/main.cr
+++ b/src/modules/views/main.cr
@@ -53,7 +53,7 @@ module Hashbrown
     Hashbrown::Verify.init
 
     CSS.load_from_data({{read_file("./src/modules/ui/style.css")}}.bytes)
-    Gtk::StyleContext.add_provider_for_display(window.display, CSS, 600_u32)
+    Gtk::StyleContext.add_provider_for_display(window.display, CSS, Gtk::STYLE_PROVIDER_PRIORITY_APPLICATION.to_u32)
 
     window.content = WINDOW_BOX
     window.present

--- a/src/modules/views/main.cr
+++ b/src/modules/views/main.cr
@@ -10,7 +10,7 @@ module Hashbrown
     window.title = "Hashbrown"
     window.set_default_size(600, 460)
     window.width_request = 360
-    window.height_request = 294
+    window.height_request = 438
     @@main_window_id = window.id
 
     Hashbrown.generate_headbar

--- a/src/modules/views/main.cr
+++ b/src/modules/views/main.cr
@@ -52,6 +52,9 @@ module Hashbrown
     Hashbrown::Compare.init
     Hashbrown::Verify.init
 
+    CSS.load_from_data({{read_file("./src/modules/ui/style.css")}}.bytes)
+    Gtk::StyleContext.add_provider_for_display(window.display, CSS, 600_u32)
+
     window.content = WINDOW_BOX
     window.present
   end


### PR DESCRIPTION
![Hashbrown hash list view on desktop with the hashes in the row subtitles](https://user-images.githubusercontent.com/18014039/145310302-acb05ef5-c810-4331-b1a1-89701802cc1c.png)

![Hashbrown hash list view on mobile with the hashes in the row subtitles](https://user-images.githubusercontent.com/18014039/145310305-a3bb47cc-8a09-44f8-aab5-0701f2752168.png)

(CSS gets loaded using macros)

closes: #30