### PR TITLE
feat: channels -> fibers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 PREFIX ?= /usr
 
 all:
-	$(CRYSTAL_LOCATION)shards build --release --no-debug
+	$(CRYSTAL_LOCATION)shards build -Dpreview_mt --release --no-debug
 
 test:
 	$(CRYSTAL_LOCATION)crystal spec

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
 
 1. Install crystal
 2. `$ shards install`
-3. `$ crystal build src/hashbrown.cr --release`
+3. `$ crystal build -Dpreview_mt src/hashbrown.cr --release`
 
 #### Makefile
 

--- a/extra/dev.geopjr.Hashbrown.json
+++ b/extra/dev.geopjr.Hashbrown.json
@@ -80,7 +80,7 @@
       "buildsystem": "simple",
       "build-commands": [
       	"for i in ./lib/*/; do ln -snf \"..\" \"$i/lib\"; done",
-        "./crystal/bin/crystal build ./src/hashbrown.cr # --no-debug --release"
+        "./crystal/bin/crystal build -Dpreview_mt ./src/hashbrown.cr # --no-debug --release"
       ],
       "post-install": [
         "install -D -m 0755 hashbrown /app/bin/hashbrown",

--- a/shard.yml
+++ b/shard.yml
@@ -16,6 +16,6 @@ dependencies:
     github: elorest/compiled_license
     version: ~> 1.2.1
 
-crystal: 1.3.0
+crystal: 1.3.2
 
 license: BSD-2-Clause

--- a/spec/copy_spec.cr
+++ b/spec/copy_spec.cr
@@ -13,10 +13,12 @@ describe "run_cmd" do
     hashes = [] of String
     channel = Channel(Hash(String, String)).new
 
-    ["sha512", "sha256", "md5", "sha1"].each do |x|
-      spawn(Hashbrown.calculate_hash(x, path.to_s, channel))
-      hashes << channel.receive[x.upcase]
+    spawn do
+      ["sha512", "sha256", "md5", "sha1"].each do |x|
+        hashes << Hashbrown.calculate_hash(x, path.to_s)
+      end
     end
+    Fiber.yield
 
     hashes.should eq(["2ddb9cca7753a01fcbcdbacc228ae8c314ff4e735c6fffb42286272fb460930dc74f122a9f365053a13016b22403ad4e192142e8668bc5f7d6fce865eb38ec2c", "08e3dfc089e66c44ae8abd3476b0f810f11f4cfc2ab925f1607c7df21345d639", "f7e3f382f0382147661c82af20e274e8", "c8f0b71214e8164aa69419b7ac0bcd8a74f529a6"])
   end

--- a/spec/copy_spec.cr
+++ b/spec/copy_spec.cr
@@ -13,7 +13,7 @@ describe "run_cmd" do
     hashes = [] of String
     channel = Channel(Hash(String, String)).new
 
-    spawn do
+    Hashbrown.non_blocking_spawn do
       ["sha512", "sha256", "md5", "sha1"].each do |x|
         hashes << Hashbrown.calculate_hash(x, path.to_s)
       end

--- a/src/hashbrown.cr
+++ b/src/hashbrown.cr
@@ -23,6 +23,7 @@ module Hashbrown
   B_HS = Gtk::Builder.new_from_string(HS, HS.bytesize.to_i64)
   B_TL = Gtk::Builder.new_from_string(TL, TL.bytesize.to_i64)
   B_HT = Gtk::Builder.new_from_string(HT, HT.bytesize.to_i64)
+  B_SP = Gtk::Builder.new_from_string(SP, SP.bytesize.to_i64)
 
   WINDOW_BOX = Gtk::Box.new(Gtk::Orientation::Vertical, 0)
   HEADERBAR  = Adw::HeaderBar.new
@@ -35,6 +36,7 @@ module Hashbrown
   HEADER_TITLE                 = Adw::ViewSwitcherTitle.cast(B_HT["switcher_title"])
   BOTTOM_TABS                  = Adw::ViewSwitcherBar.cast(B_HT["switcher_bar"])
   STACK                        = Adw::ViewStack.cast(B_HT["stack"])
+  SPINNER                      = Gtk::Spinner.cast(B_SP["spinner"])
 
   TOOL_VERIFY_ROW    = Adw::ActionRow.cast(B_TL["tool1Row"])
   TOOL_VERIFY_BUTTON = Gtk::Button.cast(B_TL["verifyBtn"])

--- a/src/modules/functions/file_set.cr
+++ b/src/modules/functions/file_set.cr
@@ -34,6 +34,15 @@ module Hashbrown
   def set_file(filepath : Path)
     HASH_LIST.title = filepath.basename.to_s
     HASH_LIST.description = filepath.dirname.to_s
-    Hashbrown.generate_hashes(filepath.to_s)
+
+    OPEN_FILE_BUTTON.visible = false
+    WINDOW_BOX.remove(STACK)
+    WINDOW_BOX.remove(BOTTOM_TABS)
+
+    Hashbrown.generate_hashes(filepath.to_s) do
+      OPEN_FILE_BUTTON.visible = true
+      WINDOW_BOX.append(STACK)
+      WINDOW_BOX.append(BOTTOM_TABS)
+    end
   end
 end

--- a/src/modules/functions/file_set.cr
+++ b/src/modules/functions/file_set.cr
@@ -39,8 +39,17 @@ module Hashbrown
     WINDOW_BOX.remove(STACK)
     WINDOW_BOX.remove(BOTTOM_TABS)
 
+    spinner = SPINNER
+    spinner.vexpand = true
+    spinner.width_request = 32
+    spinner.height_request = 32
+    spinner.start
+
+    WINDOW_BOX.append(spinner)
+
     Hashbrown.generate_hashes(filepath.to_s) do
       OPEN_FILE_BUTTON.visible = true
+      WINDOW_BOX.remove(spinner)
       WINDOW_BOX.append(STACK)
       WINDOW_BOX.append(BOTTOM_TABS)
     end

--- a/src/modules/functions/generate_hash.cr
+++ b/src/modules/functions/generate_hash.cr
@@ -22,26 +22,20 @@ module Hashbrown
     output
   end
 
-  def calculate_hash(type : String, filename : String, channel : Channel(Hash(String, String))) : Channel(Hash(String, String))
+  def calculate_hash(type : String, filename : String) : String
     hash = @@digest[type.downcase]
     hash.reset
-    channel.send({type.upcase => hash.file(filename).final.hexstring.downcase})
+    hash.file(filename).final.hexstring.downcase
   end
 
   def generate_hashes(filename : String)
-    tempBtns = Hash(Gtk::Button, String).new
-    channel = Channel(Hash(String, String)).new
-
-    ACTION_ROWS.keys.each do |k|
-      spawn(calculate_hash("#{k}", filename, channel))
-    end
-
-    ACTION_ROWS.keys.each do |_|
-      output = channel.receive
-      hash_type = output.keys.first
-      hash_value = output[hash_type]
-      ACTION_ROWS[hash_type].subtitle = hash_value.gsub(/.{1,4}/) { |x| x + " " }[0..-2]
-      CLIPBOARD_HASH[hash_type] = hash_value
+    spawn do
+      ACTION_ROWS.keys.each do |k|
+        hash_type = k
+        hash_value = calculate_hash(k, filename)
+        ACTION_ROWS[hash_type].subtitle = hash_value.gsub(/.{1,4}/) { |x| x + " " }[0..-2]
+        CLIPBOARD_HASH[hash_type] = hash_value
+      end
     end
   end
 end

--- a/src/modules/functions/generate_hash.cr
+++ b/src/modules/functions/generate_hash.cr
@@ -28,11 +28,36 @@ module Hashbrown
     hash.file(filename).final.hexstring.downcase
   end
 
+  # This is a fork of top level spawn,
+  # but when same_thread is false, it makes sure
+  # that the fiber spawns in any worker thread BUT the current one.
+  # If only the current one is available, it falls back to leaving it to
+  # Crystal::Scheduler to decide.
+  #
+  # https://crystal-lang.org/api/1.3.2/toplevel.html#spawn%28%2A%2Cname%3AString%3F%3Dnil%2Csame_thread%3Dfalse%2C%26block%29-class-method
+  # https://github.com/crystal-lang/crystal/blob/932f193ae/src/concurrent.cr#L60-L67
+  def non_blocking_spawn(*, name : String? = nil, same_thread = false, &block)
+    fiber = Fiber.new(name, &block)
+    if same_thread
+      fiber.@current_thread.set(Thread.current)
+    else
+      threads = [] of Thread
+      Thread.unsafe_each do |thread|
+        next if thread == Thread.current
+        threads << thread
+      end
+      # If there are threads available other than the current one,
+      # set fiber's thread as a random one from the array.
+      fiber.@current_thread.set(threads.sample) unless threads.size == 0
+    end
+    Crystal::Scheduler.enqueue fiber
+    fiber
+  end
+
   def generate_hashes(filename : String)
-    spawn do
-      ACTION_ROWS.keys.each do |k|
-        hash_type = k
-        hash_value = calculate_hash(k, filename)
+    ACTION_ROWS.keys.each do |hash_type|
+      non_blocking_spawn(same_thread: false) do
+        hash_value = calculate_hash(hash_type, filename)
         ACTION_ROWS[hash_type].subtitle = hash_value.gsub(/.{1,4}/) { |x| x + " " }[0..-2]
         CLIPBOARD_HASH[hash_type] = hash_value
       end

--- a/src/modules/global_vars.cr
+++ b/src/modules/global_vars.cr
@@ -27,4 +27,5 @@ module Hashbrown
   HS = Hashbrown.translate({{read_file("./src/modules/ui/hash_list.ui")}})
   TL = Hashbrown.translate({{read_file("./src/modules/ui/tools.ui")}})
   HT = Hashbrown.translate({{read_file("./src/modules/ui/switcher.ui")}})
+  SP = Hashbrown.translate({{read_file("./src/modules/ui/spinner.ui")}})
 end

--- a/src/modules/ui/hash_list.ui
+++ b/src/modules/ui/hash_list.ui
@@ -18,7 +18,7 @@
                 <property name="focusable">0</property>
                 <child>
                   <object class="GtkButton" id="copyBtn1">
-                    <property name="tooltip-text" translatable="yes">HASHBROWN_(Copy)</property>
+                    <property name="tooltip-text" translatable="1">HASHBROWN_(Copy)</property>
                     <property name="icon-name">edit-copy-symbolic</property>
                     <property name="valign">center</property>
                     <style>
@@ -38,7 +38,7 @@
                 <property name="focusable">0</property>
                 <child>
                   <object class="GtkButton" id="copyBtn2">
-                    <property name="tooltip-text" translatable="yes">HASHBROWN_(Copy)</property>
+                    <property name="tooltip-text" translatable="1">HASHBROWN_(Copy)</property>
                     <property name="icon-name">edit-copy-symbolic</property>
                     <property name="valign">center</property>
                     <style>
@@ -58,7 +58,7 @@
                 <property name="focusable">0</property>
                 <child>
                   <object class="GtkButton" id="copyBtn3">
-                    <property name="tooltip-text" translatable="yes">HASHBROWN_(Copy)</property>
+                    <property name="tooltip-text" translatable="1">HASHBROWN_(Copy)</property>
                     <property name="icon-name">edit-copy-symbolic</property>
                     <property name="valign">center</property>
                     <style>
@@ -78,7 +78,7 @@
                 <property name="focusable">0</property>
                 <child>
                   <object class="GtkButton" id="copyBtn4">
-                    <property name="tooltip-text" translatable="yes">HASHBROWN_(Copy)</property>
+                    <property name="tooltip-text" translatable="1">HASHBROWN_(Copy)</property>
                     <property name="icon-name">edit-copy-symbolic</property>
                     <property name="valign">center</property>
                     <style>

--- a/src/modules/ui/header_left.ui
+++ b/src/modules/ui/header_left.ui
@@ -5,8 +5,8 @@
     <property name="child">
       <object class="AdwButtonContent">
         <property name="icon-name">document-open-symbolic</property>
-        <property name="label" translatable="yes">_HASHBROWN_(Open)</property>
-        <property name="tooltip-text" translatable="yes">HASHBROWN_(Open)...</property>
+        <property name="label" translatable="1">_HASHBROWN_(Open)</property>
+        <property name="tooltip-text" translatable="1">HASHBROWN_(Open)...</property>
         <property name="use-underline">True</property>
       </object>
     </property>
@@ -15,7 +15,7 @@
     </style>
   </object>
   <object class="GtkFileChooserNative" id="mainFileChooserNative">
-    <property name="title" translatable="yes">HASHBROWN_(Choose a File)</property>
+    <property name="title" translatable="1">HASHBROWN_(Choose a File)</property>
     <property name="modal">1</property>
   </object>
 </interface>

--- a/src/modules/ui/header_right.ui
+++ b/src/modules/ui/header_right.ui
@@ -16,7 +16,7 @@
   <object class="GtkMenuButton" id="menuBtn">
     <property name="menu-model">primary_menu</property>
     <property name="icon-name">open-menu-symbolic</property>
-    <property name="tooltip-text" translatable="yes">HASHBROWN_(Menu)</property>
+    <property name="tooltip-text" translatable="1">HASHBROWN_(Menu)</property>
     <style>
       <class name="flat"/>
     </style>

--- a/src/modules/ui/spinner.ui
+++ b/src/modules/ui/spinner.ui
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<interface>
+  <requires lib="gtk" version="4.0"/>
+  <object class="GtkSpinner" id="spinner">
+    <property name="spinning">1</property>
+    <property name="halign">center</property>
+  </object>
+</interface>

--- a/src/modules/ui/tools.ui
+++ b/src/modules/ui/tools.ui
@@ -11,20 +11,20 @@
           <object class="AdwActionRow" id="tool1Row">
             <property name="selectable">0</property>
             <property name="icon-name">dialog-password-symbolic</property>
-            <property name="title" translatable="yes">HASHBROWN_(Verify)</property>
-            <property name="subtitle" translatable="yes">HASHBROWN_(that a hash belongs to the file)</property>
+            <property name="title" translatable="1">HASHBROWN_(Verify)</property>
+            <property name="subtitle" translatable="1">HASHBROWN_(that a hash belongs to the file)</property>
             <property name="focusable">0</property>
             <child>
               <object class="GtkEntry" id="hashInput">
                 <property name="valign">center</property>
-                <property name="tooltip-text" translatable="yes">HASHBROWN_(Insert a MD5/SHA-1/SHA-256/SHA-512 Hash)</property>
+                <property name="tooltip-text" translatable="1">HASHBROWN_(Insert a MD5/SHA-1/SHA-256/SHA-512 Hash)</property>
                 <property name="max-width-chars">30</property>
-                <property name="placeholder-text" translatable="yes">HASHBROWN_(MD5/SHA-1/SHA-256/SHA-512 Hash)</property>
+                <property name="placeholder-text" translatable="1">HASHBROWN_(MD5/SHA-1/SHA-256/SHA-512 Hash)</property>
               </object>
             </child>
             <child>
               <object class="GtkButton" id="verifyBtn">
-                <property name="tooltip-text" translatable="yes">HASHBROWN_(Verify)</property>
+                <property name="tooltip-text" translatable="1">HASHBROWN_(Verify)</property>
                 <property name="icon-name">auth-fingerprint-symbolic</property>
                 <property name="valign">center</property>
                 <style>
@@ -38,14 +38,14 @@
           <object class="AdwActionRow" id="tool2Row">
             <property name="selectable">0</property>
             <property name="icon-name">dialog-password-symbolic</property>
-            <property name="title" translatable="yes">HASHBROWN_(Compare)</property>
-            <property name="subtitle" translatable="yes">HASHBROWN_(with another file)</property>
+            <property name="title" translatable="1">HASHBROWN_(Compare)</property>
+            <property name="subtitle" translatable="1">HASHBROWN_(with another file)</property>
             <property name="focusable">0</property>
             <child>
               <object class="GtkButton" id="compareBtn">
                 <property name="valign">center</property>
-                <property name="tooltip-text" translatable="yes">HASHBROWN_(Select Another File to Check Against)</property>
-                <property name="label" translatable="yes">_HASHBROWN_(Select a File)</property>
+                <property name="tooltip-text" translatable="1">HASHBROWN_(Select Another File to Check Against)</property>
+                <property name="label" translatable="1">_HASHBROWN_(Select a File)</property>
                 <property name="use-underline">1</property>
               </object>
             </child>
@@ -58,7 +58,7 @@
     </child>
   </object>
   <object class="GtkFileChooserNative" id="compareFileChooserNative">
-    <property name="title" translatable="yes">HASHBROWN_(Choose a File)</property>
+    <property name="title" translatable="1">HASHBROWN_(Choose a File)</property>
     <property name="modal">1</property>
   </object>
 </interface>

--- a/src/modules/ui/welcomer.ui
+++ b/src/modules/ui/welcomer.ui
@@ -6,12 +6,12 @@
     <property name="hexpand">true</property>
     <property name="icon-name">dev.geopjr.Hashbrown</property>
     <property name="title">Hashbrown</property>
-    <property name="description" translatable="yes">HASHBROWN_(Check hashes for your files)</property>
+    <property name="description" translatable="1">HASHBROWN_(Check hashes for your files)</property>
     <child>
       <object class="GtkButton" id="welcomeBtn">
         <property name="halign">center</property>
-        <property name="label" translatable="yes">_HASHBROWN_(Open a File)</property>
-	<property name="use-underline">True</property>
+        <property name="label" translatable="1">_HASHBROWN_(Open a File)</property>
+        <property name="use-underline">1</property>
         <style>
           <class name="suggested-action"/>
           <class name="pill"/>
@@ -23,7 +23,7 @@
     </style>
   </object>
   <object class="GtkFileChooserNative" id="welcomerFileChooserNative">
-    <property name="title" translatable="yes">HASHBROWN_(Choose a File)</property>
+    <property name="title" translatable="1">HASHBROWN_(Choose a File)</property>
     <property name="modal">1</property>
   </object>
 </interface>

--- a/src/modules/views/tools/compare.cr
+++ b/src/modules/views/tools/compare.cr
@@ -10,13 +10,11 @@ module Hashbrown
       TOOL_COMPARE_FILE_CHOOSER_NATIVE.response_signal.connect do |response|
         next unless response == -3
 
-        channel = Channel(Hash(String, String)).new
-        spawn(Hashbrown.calculate_hash("sha256", TOOL_COMPARE_FILE_CHOOSER_NATIVE.file.path.to_s, channel))
-
-        compareFileSHA256 = channel.receive["SHA256"]
-        result = CLIPBOARD_HASH["SHA256"] == compareFileSHA256
-
-        TOOL_COMPARE_ROW.icon_name = Hashbrown.icon(result)
+        spawn do
+          compareFileSHA256 = Hashbrown.calculate_hash("sha256", TOOL_COMPARE_FILE_CHOOSER_NATIVE.file.path.to_s)
+          result = CLIPBOARD_HASH["SHA256"] == compareFileSHA256
+          TOOL_COMPARE_ROW.icon_name = Hashbrown.icon(result)
+        end
       end
     end
   end

--- a/src/modules/views/tools/compare.cr
+++ b/src/modules/views/tools/compare.cr
@@ -10,7 +10,7 @@ module Hashbrown
       TOOL_COMPARE_FILE_CHOOSER_NATIVE.response_signal.connect do |response|
         next unless response == -3
 
-        Hashbrown.non_blocking_spawn do
+        Hashbrown.handle_spawning do
           compareFileSHA256 = Hashbrown.calculate_hash("sha256", TOOL_COMPARE_FILE_CHOOSER_NATIVE.file.path.to_s)
           result = CLIPBOARD_HASH["SHA256"] == compareFileSHA256
           TOOL_COMPARE_ROW.icon_name = Hashbrown.icon(result)

--- a/src/modules/views/tools/compare.cr
+++ b/src/modules/views/tools/compare.cr
@@ -10,7 +10,7 @@ module Hashbrown
       TOOL_COMPARE_FILE_CHOOSER_NATIVE.response_signal.connect do |response|
         next unless response == -3
 
-        spawn do
+        Hashbrown.non_blocking_spawn do
           compareFileSHA256 = Hashbrown.calculate_hash("sha256", TOOL_COMPARE_FILE_CHOOSER_NATIVE.file.path.to_s)
           result = CLIPBOARD_HASH["SHA256"] == compareFileSHA256
           TOOL_COMPARE_ROW.icon_name = Hashbrown.icon(result)

--- a/src/modules/views/tools/compare.cr
+++ b/src/modules/views/tools/compare.cr
@@ -10,9 +10,19 @@ module Hashbrown
       TOOL_COMPARE_FILE_CHOOSER_NATIVE.response_signal.connect do |response|
         next unless response == -3
 
+        # Adding and then removing a prefix introduces extra padding (GtkBox), disabled for now.
+        # Tracked: https://gitlab.gnome.org/GNOME/libadwaita/-/issues/395
+        #
+        # TOOL_COMPARE_ROW.icon_name = nil
+        # spinner = SPINNER
+        # spinner.start
+        # TOOL_COMPARE_ROW.add_prefix(spinner)
+        TOOL_COMPARE_ROW.icon_name = "process-working-symbolic"
+
         Hashbrown.handle_spawning do
           compareFileSHA256 = Hashbrown.calculate_hash("sha256", TOOL_COMPARE_FILE_CHOOSER_NATIVE.file.path.to_s)
           result = CLIPBOARD_HASH["SHA256"] == compareFileSHA256
+          # TOOL_COMPARE_ROW.remove(spinner)
           TOOL_COMPARE_ROW.icon_name = Hashbrown.icon(result)
         end
       end


### PR DESCRIPTION
This PR replaces the use of channels with fibers.

Spawning each calculation in individual fibers seems to get at least one blocked in the main one, so we just spawn one for now. Additionally an extra flag is needed at compile time to enable concurrency, `-Dpreview_mt`.

closes: #37